### PR TITLE
Implemented the HclWriter

### DIFF
--- a/source/Hcl/HAttribute.cs
+++ b/source/Hcl/HAttribute.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    /// A HCL attribute, <code>MyAttribute = value</code>
+    /// <seealso cref="https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md#attribute-definitions" />
+    /// </summary>
+    /// <remarks>
+    /// An attribute definition assigns a value to a particular attribute name within a body. Each distinct attribute name may be defined no more than once within a single body.
+    /// </remarks>
+    public class HAttribute : IHElement
+    {
+        private string name;
+
+        public HAttribute(string name, object? value)
+        {
+            this.name = Name = name; // Make the compiler happy
+            Value = value;
+        }
+
+        public string Name
+        {
+            get => name;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentException("Attribute names cannot be blank");
+                name = value;
+            }
+        }
+
+        /// <remarks>
+        /// The attribute value is given as an expression, which is retained literally for later evaluation by the calling application.
+        /// </remarks>
+        public object? Value { get; set; }
+    }
+}

--- a/source/Hcl/HBlock.cs
+++ b/source/Hcl/HBlock.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    /// A HCL block, <code>MyThing "ALabel" { ... }</code>
+    /// <seealso cref="https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md#blocks" />
+    /// </summary>
+    /// <remarks>
+    /// A block creates a child body that is annotated with a block type and zero or more block labels. Blocks create a
+    /// structural hierarchy which can be interpreted by the calling application.
+    /// </remarks>
+    public class HBlock : HBody, IHElement
+    {
+        private string name;
+
+        public HBlock(string name)
+        {
+            this.name = Name = name; // Make the compiler happy
+        }
+
+        public string Name
+        {
+            get => name;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentException("Block names cannot be blank");
+                name = value;
+            }
+        }
+
+        /// <remarks>
+        /// Block labels can either be quoted literal strings or naked identifiers.
+        /// </remarks>
+        public List<string> Labels { get; } = new List<string>();
+    }
+}

--- a/source/Hcl/HBody.cs
+++ b/source/Hcl/HBody.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    ///     <seealso cref="https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md#bodies" />
+    /// </summary>
+    /// <remarks>
+    /// A body is a collection of associated attributes and blocks. The meaning of this association is defined by the calling application.
+    /// </remarks>
+    public class HBody : IEnumerable<IHElement>
+    {
+        private readonly List<IHElement> elements = new List<IHElement>();
+
+        public IEnumerator<IHElement> GetEnumerator()
+            => elements.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public void Add(IHElement element)
+            => elements.Add(element);
+    }
+}

--- a/source/Hcl/HDocument.cs
+++ b/source/Hcl/HDocument.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    public class HDocument : HBody
+    {
+    }
+}

--- a/source/Hcl/HclConvert.cs
+++ b/source/Hcl/HclConvert.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Text;
+
+namespace Octopus.Hcl
+{
+    public class HclConvert
+    {
+        public static string Serialize(HDocument document, HclSerializerOptions? options = null)
+        {
+            options ??= new HclSerializerOptions();
+            var sb = new StringBuilder();
+            // ReSharper disable once ConvertToUsingDeclaration
+            using (var writer = new HclWriter(sb, options))
+            {
+                writer.Write(document);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/source/Hcl/HclSerializer.cs
+++ b/source/Hcl/HclSerializer.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    /// This class is thread safe
+    /// </summary>
+    public class HclSerializer
+    {
+        public HclSerializer(HclSerializerOptions? options = null)
+        {
+            Options = options ?? new HclSerializerOptions();
+        }
+
+        public HclSerializerOptions Options { get; }
+
+        public string Serialize(HDocument document)
+            => HclConvert.Serialize(document, Options);
+    }
+}

--- a/source/Hcl/HclSerializerOptions.cs
+++ b/source/Hcl/HclSerializerOptions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    /// This class is not threadsafe while it is being used to serialize/deserialize
+    /// </summary>
+    public class HclSerializerOptions
+    {
+        public char IndentChar { get; set; } = ' ';
+        public int IndentDepth { get; set; } = 4;
+        public string DefaultHeredocIdentifier { get; set; } = "EOT";
+    }
+}

--- a/source/Hcl/HclStringLiteral.cs
+++ b/source/Hcl/HclStringLiteral.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    public enum HclStringLiteralFormat
+    {
+        SingleLine = 0,
+        Heredoc = 1,
+        IndentedHeredoc = 2
+    }
+
+    public class HclStringLiteral
+    {
+        public HclStringLiteral(string value, HclStringLiteralFormat format)
+        {
+            Value = value;
+            Format = format;
+        }
+
+        public string Value { get; }
+        public HclStringLiteralFormat Format { get; }
+        public string HeredocIdentifier { get; set; } = "EOT";
+
+        public static HclStringLiteral Create(string value)
+            => new HclStringLiteral(value, value.Contains('\n') ? HclStringLiteralFormat.IndentedHeredoc : HclStringLiteralFormat.SingleLine);
+    }
+}

--- a/source/Hcl/HclWriter.cs
+++ b/source/Hcl/HclWriter.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Text;
+
+namespace Octopus.Hcl
+{
+    /// <summary>
+    /// This class is not threadsafe
+    /// </summary>
+    public class HclWriter : IDisposable
+    {
+        private readonly TextWriter writer;
+        private int currentIndent;
+        private bool isFirstLine = true;
+        private bool lastWrittenWasBlock;
+
+        public HclWriter(StringBuilder sb, HclSerializerOptions? options = null)
+            : this(new StringWriter(sb), options)
+        {
+        }
+
+        public HclWriter(TextWriter writer, HclSerializerOptions? options = null)
+        {
+            this.writer = writer;
+            Options = options ?? new HclSerializerOptions();
+        }
+
+        public HclSerializerOptions Options { get; }
+
+        public void Write(IHElement element)
+        {
+            switch (element)
+            {
+                case HAttribute attribute:
+                    Write(attribute);
+                    return;
+                case HBlock block:
+                    Write(block);
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(element.GetType().Name);
+            }
+        }
+
+        public void Write(HBody body)
+        {
+            foreach (var item in body)
+                Write(item);
+        }
+
+        public void Write(HAttribute attribute)
+        {
+            WriteNextLine();
+            WriteIndent();
+            WriteIdentifier(attribute.Name);
+            writer.Write(" = ");
+            WriteValue(attribute.Value);
+        }
+
+        public void Write(HBlock block)
+        {
+            if (!isFirstLine && !lastWrittenWasBlock)
+                writer.WriteLine();
+            WriteNextLine();
+            WriteIndent();
+            WriteIdentifier(block.Name);
+
+            foreach (var label in block.Labels)
+            {
+                writer.Write(' ');
+                WriteSingleLineStringLiteral(label);
+            }
+
+            writer.Write(" {");
+
+            currentIndent += Options.IndentDepth;
+            foreach (var child in block)
+                Write(child);
+            currentIndent -= Options.IndentDepth;
+
+            writer.WriteLine();
+
+            WriteIndent();
+            writer.Write("}");
+
+            lastWrittenWasBlock = true;
+        }
+
+        private void WriteNextLine()
+        {
+            if (!isFirstLine)
+                writer.WriteLine();
+            if (lastWrittenWasBlock)
+                writer.WriteLine();
+            isFirstLine = false;
+            lastWrittenWasBlock = false;
+        }
+
+        private void WriteIndent()
+        {
+            for (var x = 0; x < currentIndent; x++)
+                writer.Write(Options.IndentChar);
+        }
+
+        private void WriteIdentifier(string identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+                throw new ArgumentException("Identifier cannot be blank");
+
+            if (char.IsDigit(identifier[0]))
+                writer.Write('_');
+
+            foreach (var c in identifier)
+                if (
+                    char.IsLetterOrDigit(c) ||
+                    c == '_' ||
+                    c == '-'
+                )
+                    writer.Write(c);
+                else
+                    writer.Write('_');
+        }
+
+        private void WriteValue(object? value)
+        {
+            if (value == null)
+            {
+                writer.Write("null");
+                return;
+            }
+
+            switch (value)
+            {
+                case bool b:
+                    writer.Write(b ? "true" : "false");
+                    return;
+                case byte b:
+                    writer.Write(b);
+                    return;
+                case ushort s:
+                    writer.Write(s);
+                    return;
+                case short s:
+                    writer.Write(s);
+                    return;
+                case uint i:
+                    writer.Write(i);
+                    return;
+                case int i:
+                    writer.Write(i);
+                    return;
+                case ulong l:
+                    writer.Write(l);
+                    return;
+                case long l:
+                    writer.Write(l);
+                    return;
+                case float f:
+                    writer.Write(f);
+                    return;
+                case double d:
+                    writer.Write(d);
+                    return;
+                case decimal d:
+                    writer.Write(d);
+                    return;
+                case char c:
+                    WriteSingleLineStringLiteral(c.ToString());
+                    return;
+                case string s:
+                    var literal = HclStringLiteral.Create(s);
+                    literal.HeredocIdentifier = Options.DefaultHeredocIdentifier;
+                    WriteValue(literal);
+                    return;
+                case HclStringLiteral s:
+                    WriteValue(s);
+                    return;
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                writer.Write('[');
+                var isFirst = true;
+                foreach (var item in enumerable)
+                {
+                    if (!isFirst)
+                        writer.Write(", ");
+                    isFirst = false;
+                    WriteValue(item);
+                }
+
+                writer.Write(']');
+                return;
+            }
+
+            throw new InvalidOperationException($"The type {value.GetType().FullName} is not a valid attribute value and can not be serialized");
+        }
+
+        private void WriteValue(HclStringLiteral literal)
+        {
+            if (literal.Format == HclStringLiteralFormat.SingleLine)
+            {
+                WriteSingleLineStringLiteral(literal.Value);
+                return;
+            }
+
+            var isIndented = literal.Format == HclStringLiteralFormat.IndentedHeredoc;
+
+            writer.Write("<<");
+            if (isIndented)
+                writer.Write("-");
+            writer.WriteLine(literal.HeredocIdentifier);
+
+            foreach (var line in literal.Value.Split('\n'))
+            {
+                if (isIndented)
+                    WriteIndent();
+                writer.WriteLine(line.TrimEnd('\r'));
+            }
+
+            if (isIndented)
+                WriteIndent();
+            writer.Write(literal.HeredocIdentifier);
+        }
+
+        private void WriteSingleLineStringLiteral(string s)
+        {
+            writer.Write('"');
+            writer.Write(s.Replace("\"", "\\\""));
+            writer.Write('"');
+        }
+
+        public void Dispose()
+        {
+            writer.Dispose();
+        }
+    }
+}

--- a/source/Hcl/IHElement.cs
+++ b/source/Hcl/IHElement.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Octopus.Hcl
+{
+    public interface IHElement
+    {
+        string Name { get; set; }
+    }
+}

--- a/source/Tests/HclWriterFixture.cs
+++ b/source/Tests/HclWriterFixture.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Hcl;
+
+namespace Tests
+{
+    [Parallelizable(ParallelScope.All)]
+    public class HclWriterFixture
+    {
+        private static IEnumerable<TestCaseData> WriteAttributeDataSource()
+        {
+            TestCaseData CreateCase(string name, object? value, string expected)
+                => new TestCaseData(value, expected) { TestName = "WriteAttribute value: " + name };
+
+            yield return CreateCase("null", null, "null");
+            yield return CreateCase("bool", false, "false");
+            yield return CreateCase("char", '5', "\"5\"");
+            yield return CreateCase("byte", (byte)5, "5");
+            yield return CreateCase("short", (short)-5, "-5");
+            yield return CreateCase("ushort", (ushort)5, "5");
+            yield return CreateCase("uint", 5u, "5");
+            yield return CreateCase("int", 5, "5");
+
+            yield return CreateCase("negative", -5, "-5");
+            yield return CreateCase("long", -4398257458902378590L, "-4398257458902378590");
+            yield return CreateCase("ulong", 4398257458902437590uL, "4398257458902437590");
+            yield return CreateCase("float", 3243242.43432f, "3243242.5");
+            yield return CreateCase("double", 3243242.43432d, "3243242.43432");
+            yield return CreateCase("double small exponential", 3243242e+3, "3243242000");
+            yield return CreateCase("double large exponential", 3243242e+34, "3.243242E+40");
+            yield return CreateCase("decimal", 3243242.43432m, "3243242.43432");
+            yield return CreateCase("string", "MyValue", @"""MyValue""");
+            yield return CreateCase("double quotes", @"a""b", @"""a\""b""");
+            yield return CreateCase("string array", new[] { "B", "C" }, @"[""B"", ""C""]");
+            yield return CreateCase("Int array", new[] { 4, 3, 4 }, @"[4, 3, 4]");
+            yield return CreateCase("string with newlines", new HclStringLiteral(@"a\r\nb", HclStringLiteralFormat.SingleLine), @"""a\r\nb""");
+        }
+
+        [TestCaseSource(nameof(WriteAttributeDataSource))]
+        public void WriteAttribute(object? input, string expected)
+            => Execute(w => w.Write(new HAttribute("MyAttr", input)))
+                .Should()
+                .Be($"MyAttr = {expected}");
+
+        
+        [Test]
+        public void WriteAttributeInvalidValueThrows()
+        {
+            Action action = () => Execute(w => w.Write(new HAttribute("MyAttr", new Random())));
+            action.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*System.Random*");
+        }
+        
+        [Test]
+        public void WriteAttributeLeadingNumberInName()
+            => Execute(w => w.Write(new HAttribute("0MyAttr", 5)))
+                .Should()
+                .Be("_0MyAttr = 5");
+
+        [Test]
+        public void WriteAttributeSpecialCharactersInName()
+            => Execute(w => w.Write(new HAttribute("My0%&2_'\"-Attr", 5)))
+                .Should()
+                .Be("My0__2___-Attr = 5");
+    
+        [Test]
+        public void Heredoc()
+        {
+            var literal = new HclStringLiteral(" a\r\n    b", HclStringLiteralFormat.Heredoc) { HeredocIdentifier = "ZZZ" };
+            var block = new HBlock("MyBlock")
+            {
+                new HAttribute("MyAttr", literal)
+            };
+
+            var expected = @"MyBlock {
+    MyAttr = <<ZZZ
+ a
+    b
+ZZZ
+}";
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void HeredocIndented()
+        {
+            var literal = new HclStringLiteral(" a\r\n    b", HclStringLiteralFormat.IndentedHeredoc);
+            var block = new HBlock("MyBlock")
+            {
+                new HAttribute("MyAttr", literal)
+            };
+
+            var expected = @"MyBlock {
+    MyAttr = <<-EOT
+     a
+        b
+    EOT
+}";
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void MultilineStringsUseHeredocAndTheHeredocIdentifierFromOptions()
+        {
+            var options = new HclSerializerOptions
+            {
+                DefaultHeredocIdentifier = "YYY"
+            };
+
+            var expected = @"MyAttr = <<-YYY
+a
+b
+YYY";
+
+            Execute(w => w.Write(new HAttribute("MyAttr", "a\r\nb")), options)
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void WriteBlockEmpty()
+            => Execute(w => w.Write(new HBlock("MyBlock")))
+                .Should()
+                .Be("MyBlock {\r\n}");
+
+        [Test]
+        public void WriteBlockSpecialCharactersInName()
+            => Execute(w => w.Write(new HBlock("My0%&2_'\"-Block")))
+                .Should()
+                .Be("My0__2___-Block {\r\n}");
+
+        [Test]
+        public void WriteBlockSingleLabel()
+        {
+            var block = new HBlock("MyBlock");
+            block.Labels.Add("MyLabel");
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be("MyBlock \"MyLabel\" {\r\n}");
+        }
+
+        [Test]
+        public void WriteBlockMultipleLabel()
+        {
+            var block = new HBlock("MyBlock");
+            block.Labels.Add("MyLabel");
+            block.Labels.Add("OtherLabel");
+            block.Labels.Add("LastLabel");
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be("MyBlock \"MyLabel\" \"OtherLabel\" \"LastLabel\" {\r\n}");
+        }
+
+        [Test]
+        public void WriteBlockDoubleQuotesInLabel()
+        {
+            var block = new HBlock("MyBlock");
+            block.Labels.Add("My\"Label");
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be("MyBlock \"My\\\"Label\" {\r\n}");
+        }
+
+        [Test]
+        public void WriteBlockSingleChildBlock()
+        {
+            var block = new HBlock("MyBlock")
+            {
+                new HBlock("Child")
+            };
+
+            var expected = @"MyBlock {
+
+    Child {
+    }
+}";
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void WriteBlockSingleChildAttribute()
+        {
+            var block = new HBlock("MyBlock")
+            {
+                new HAttribute("Child", 5)
+            };
+
+            var expected = @"MyBlock {
+    Child = 5
+}";
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void IndentOptionsAreUsed()
+        {
+            var options = new HclSerializerOptions
+            {
+                IndentChar = '+',
+                IndentDepth = 5
+            };
+
+            var block = new HBlock("MyBlock")
+            {
+                new HAttribute("Child", 5)
+            };
+
+            var expected = @"MyBlock {
++++++Child = 5
+}";
+
+            Execute(w => w.Write(block), options)
+                .Should()
+                .Be(expected);
+        }
+
+        [Test]
+        public void WriteBlockMixedAttributesAndBlocks()
+        {
+            var block = new HBlock("MyBlock")
+            {
+                new HAttribute("First", 1),
+                new HAttribute("Second", 2),
+                new HBlock("Third")
+                {
+                    new HAttribute("ThirdChild", 3)
+                },
+                new HBlock("Fourth"),
+                new HAttribute("Last", 9)
+            };
+
+            var expected = @"MyBlock {
+    First = 1
+    Second = 2
+
+    Third {
+        ThirdChild = 3
+    }
+
+    Fourth {
+    }
+
+    Last = 9
+}";
+
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected);
+        }
+
+
+        private string Execute(Action<HclWriter> when, HclSerializerOptions? options = null)
+        {
+            var sb = new StringBuilder();
+            using (var writer = new HclWriter(sb, options))
+            {
+                when(writer);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -8,4 +8,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Hcl\Hcl.csproj" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions.Extensions" Version="1.0.18" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds the basic HCL Abstract Syntax Tree (AST) elements and a `HclWriter` to write them out.

The API is modeled after `Newtonsoft.Json` and allows mutation of the AST.

I intend for the conversion of non-builtin values (e.g. TinyTypes) to be done at the object -> AST conversion stage.

There are 3 more parts to come:
- object -> AST conversion
- text -> AST
- AST -> object